### PR TITLE
[FIX] Admin::RegistrationsController

### DIFF
--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-layout 'admin'
 class Admin::RegistrationsController < Devise::RegistrationsController
+  layout 'admin'
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 


### PR DESCRIPTION
Admin::RegistrationsController "layout 'admin'" 記載位置の修正